### PR TITLE
admin: date and show-listing updates

### DIFF
--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -80,8 +80,8 @@ router.get('/shows/', checkUserSilently, function(req: IRequestWithUser, res: Re
   show.getAll(req.user, req.query.production_id).then(ok(res), err(res));
 });
 
-router.get('/shows/:showid', function(req: Request, res: Response) {
-  show.get(parseInt(req.params.showid)).then(ok(res), err(res));
+router.get('/shows/:showid', checkUserSilently, function(req: IRequestWithUser, res: Response) {
+  show.get(parseInt(req.params.showid), req.user).then(ok(res), err(res));
 });
 
 router.get('/shows/:showid/reservedSeats', function(req: Request, res: Response) {

--- a/frontend/src/js-admin/components/Home.tsx
+++ b/frontend/src/js-admin/components/Home.tsx
@@ -5,26 +5,26 @@ import Backbone = require('backbone');
 import $ = require('jquery');
 import _ = require('underscore');
 
-import {IShow, IReservedSeats} from '../../../../backend/src/show';
-import {IVenue, ISection, ISeat} from '../../../../backend/src/venue';
+import ShowList from './ShowList';
+
+import {IVenue} from '../../../../backend/src/venue';
 import {IProduction} from '../../../../backend/src/production';
-import {ISOToDateString} from '../utils';
 
 export interface IHomeState {
-  shows?: IShow[];
   venues?: IVenue[];
+  production?: IProduction; // latest
   productions?: IProduction[];
 }
 
 export default class Home extends React.Component<any, IHomeState> {
   constructor() {
     super();
-    this.state = {shows: [], venues: [], productions: []};
+    this.state = {venues: [], productions: []};
   }
 
   componentWillMount() {
-    $.getJSON('api/shows', (resp: IShow[]) => {
-      this.setState({shows: resp});
+    $.getJSON('api/productions/latest', (resp: IProduction) => {
+      this.setState({production: resp});
     });
     $.getJSON('admin-api/venues', (resp: IVenue[]) => {
       this.setState({venues: resp});
@@ -39,11 +39,7 @@ export default class Home extends React.Component<any, IHomeState> {
       <div>
         <a href={'#discountCodes/'}><h2>Alennuskoodit</h2></a>
         <a href={'#discountGroups/'}><h2>Alennusryhmät</h2></a>
-        <h2>Näytökset</h2>
-        <p><a href={'#shows/'}>Luo uusi näytös</a></p>
-        <ul>
-          {this.state.shows.map((show) => <li key={show.id}><a href={'#shows/' + show.id}>{ISOToDateString(show.time)} {show.title}</a> - <a href={'#shows/' + show.id + '/orders'}>Tilaukset</a></li>)}
-        </ul>
+        {this.state.production ? <ShowList production={this.state.production} /> : null}
         <h2>Teatterit</h2>
         <p><a href={'#venues/'}>Luo uusi teatteri</a></p>
         <ul>

--- a/frontend/src/js-admin/components/OrderList.tsx
+++ b/frontend/src/js-admin/components/OrderList.tsx
@@ -4,10 +4,10 @@ import React = require('react');
 import $ = require('jquery');
 import _ = require('underscore');
 import Bootstrap = require('react-bootstrap');
+import Moment = require('moment-timezone');
 
 import {IAdminOrderListItem} from '../../../../backend/src/order';
 import {IShow} from '../../../../backend/src/show';
-import {ISOToDateString} from '../utils';
 
 export interface IOrderListProps {
   show_id?: number;
@@ -50,7 +50,7 @@ export default class OrderList extends React.Component<IOrderListProps, IOrderLi
     return (
       <div>
         <h2>
-          {this.state.show ? 'Tilaukset - ' + ISOToDateString(this.state.show.time) + ' ' + this.state.show.title : ''}
+          {this.state.show ? 'Tilaukset - ' + Moment.tz(this.state.show.time, 'Europe/Helsinki').format('D.M.YYYY') + ' ' + this.state.show.title : ''}
         </h2>
         <Bootstrap.Table bordered striped condensed><tbody>
         <tr>

--- a/frontend/src/js-admin/components/Production.tsx
+++ b/frontend/src/js-admin/components/Production.tsx
@@ -5,9 +5,11 @@ import $ = require('jquery');
 import _ = require('underscore');
 import Bootstrap = require('react-bootstrap');
 
-import SeatSelector from './SeatSelector';
+import ShowList from './ShowList';
 import editable = require('./editables');
+
 import {IProduction} from '../../../../backend/src/production';
+import {IShow} from '../../../../backend/src/show';
 
 
 export interface IProductionProps {
@@ -109,6 +111,7 @@ export default class Production extends React.Component<IProductionProps, IProdu
         </tbody></Bootstrap.Table>
         <Bootstrap.Button disabled={!hasEdits} onClick={this.saveChanges.bind(this)}>Tallenna muutokset</Bootstrap.Button>
         <Bootstrap.Button disabled={!hasEdits} onClick={() => this.reset()}>Peru</Bootstrap.Button>
+        <ShowList production={this.state.production} />
       </div>
     );
   }

--- a/frontend/src/js-admin/components/ShowList.tsx
+++ b/frontend/src/js-admin/components/ShowList.tsx
@@ -1,0 +1,50 @@
+'use strict';
+
+import React = require('react');
+import Backbone = require('backbone');
+import $ = require('jquery');
+import _ = require('underscore');
+import Moment = require('moment-timezone');
+
+import {IProduction} from '../../../../backend/src/production';
+import {IShow} from '../../../../backend/src/show';
+
+export interface IShowListProps {
+  production: IProduction;
+}
+
+export interface IShowListSate {
+  shows?: IShow[];
+}
+
+export default class ShowList extends React.Component<IShowListProps, IShowListSate> {
+  constructor() {
+    super();
+    this.state = {shows: []};
+  }
+
+  componentWillMount() {
+    $.getJSON('api/shows', {production_id: this.props.production.id}, (resp: IShow[]) => {
+      this.setState({shows: resp});
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <h2>Näytökset: {this.props.production ? this.props.production.title : ''}</h2>
+        <p><a href={'#shows/'}>Luo uusi näytös</a></p>
+        <ul>
+          {this.state.shows.map((show) =>
+            <li key={show.id}>
+              <a href={'#shows/' + show.id}>{Moment.tz(show.time, 'Europe/Helsinki').format('D.M.YYYY')} {show.title}</a>
+              &nbsp;-&nbsp;
+              <a href={'#shows/' + show.id + '/orders'}>Tilaukset</a>
+            </li>)
+          }
+        </ul>
+      </div>
+    );
+  }
+
+}

--- a/frontend/src/js-admin/components/editables.tsx
+++ b/frontend/src/js-admin/components/editables.tsx
@@ -2,6 +2,7 @@ import React = require('react');
 import $ = require('jquery');
 import _ = require('underscore');
 import Bootstrap = require('react-bootstrap');
+import Moment = require('moment-timezone');
 
 function _onChange(_this: any, obj: {}, field: string, event, type?: string) {
   if (type === 'number') {
@@ -11,7 +12,7 @@ function _onChange(_this: any, obj: {}, field: string, event, type?: string) {
   } else if (type === 'checkbox') {
     obj[field] = event.target.checked ? 1 : 0;
   } else if (type === 'datetime') {
-    obj[field] = event.target.value;
+    obj[field] = Moment.tz(event.target.value, 'Europe/Helsinki').format('YYYY-MM-DD HH:mm:00');
   } else if (type === 'stringList') {
     obj[field] = event.target.value.split('\n');
   } else {
@@ -63,10 +64,11 @@ export function Number(_this: any, obj: {}, field: string, onChange?: (_this: an
 }
 
 export function Date(_this: any, obj: {}, field: string, onChange?: (_this: any, obj: {}, field: string, event, type?: string) => void) {
+  var val = Moment.tz(obj[field], 'Europe/Helsinki').format('YYYY-MM-DDTHH:mm');
   if (!onChange) {
     onChange = _onChange;
   }
-  return (<input type='datetime-local' value={obj[field]} onChange={(event) => onChange(_this, obj, field, event, 'datetime')}/>);
+  return (<input type='datetime-local' value={val} onChange={(event) => onChange(_this, obj, field, event, 'datetime')}/>);
 }
 
 export function Checkbox(_this: any, obj: {}, field: string, onChange?: (_this: any, obj: {}, field: string, event, type?: string) => void) {

--- a/frontend/src/js-admin/utils.ts
+++ b/frontend/src/js-admin/utils.ts
@@ -1,7 +1,0 @@
-'use strict';
-
-export function ISOToDateString(ISOString: string) {
-  var dateObj = new Date(ISOString);
-  var month = dateObj.getMonth() + 1;
-  return dateObj.getDate() + '.' + month;
-}


### PR DESCRIPTION
Fix admin to show dates correctly, using Moment.
Move Show listing to a component and reuse in Production edit.
Only show current production's shows in the main listing.
Cleanup.