### PR TITLE
Improve dev auth: use basic auth but allow any username/password

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -56,12 +56,13 @@ app.get('/favicon.ico', function(req, res: Response) {
   res.send('');
 });
 
+
+app.all('/admin*', httpAuth.connect(adminAuth));
+app.all('/checker*', httpAuth.connect(checkerAuth));
+
 if (config.confluence_auth.enabled) {
-  app.all('/admin*', httpAuth.connect(adminAuth));
-  app.all('/checker*', httpAuth.connect(checkerAuth));
-} else {
   log.warn('=======================================');
-  log.warn('NO AUTHENTICATION ENABLED. Fine for dev, not cool for anything real.');
+  log.warn('NO REAL AUTHENTICATION ENABLED. Use any username/password. Fine for dev, not cool for anything real.');
   log.warn('=======================================');
 }
 

--- a/backend/src/confluenceAuth.ts
+++ b/backend/src/confluenceAuth.ts
@@ -16,6 +16,11 @@ export function isAdmin(user: string) {
 }
 
 export function authenticate(user: string, password: string, requiredGroup: string, cb: Function) {
+  if (!config.confluence_auth.enabled) {
+    log.warn('NO REAL AUTHENTICATION ENABLED. Accepting ' + user + '.');
+    return cb(true);
+  }
+
   if (userCache[user] && userCache[user].password === password) {
     var now = new Date();
     if (now.getTime() - userCache[user].inserted.getTime() > CACHE_INVALIDATE_MSEC) {


### PR DESCRIPTION
This is needed as many admin functionalities check whether user is admin
by checking if there is a user, and disabling basic auth totally means
no user info.