### PR TITLE
Add from-address to error log sending

### DIFF
--- a/backend/src/log.ts
+++ b/backend/src/log.ts
@@ -26,6 +26,7 @@ if (config.email.errors_to) {
   transports.push(new (winston.transports.MailGun)({
     level: 'error',
     to: config.email.errors_to,
+    from: config.email.errors_from,
     apiKey: config.email.mailgun.api_key,
     domain: config.email.mailgun.domain
   }));

--- a/config/config-sample.js
+++ b/config/config-sample.js
@@ -15,7 +15,7 @@ module.exports = {
         },
     from: '',
     errors_to: '',
-    errors_from: '',
+    errors_from: ''
   },
   paytrail: {
     user: '13466',

--- a/config/config-sample.js
+++ b/config/config-sample.js
@@ -14,7 +14,8 @@ module.exports = {
           domain: ''
         },
     from: '',
-    errors_to: ''
+    errors_to: '',
+    errors_from: '',
   },
   paytrail: {
     user: '13466',


### PR DESCRIPTION
Seemed like we missed all error messages this spring as mailgun didn't
like our hostname as from-address. So let's set up a better from-address
for next time.