### PR TITLE
Anonymize PII after 6 months

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -18,8 +18,13 @@ var adminApi = require('./backend/build/routes-admin');
 var checkerApi = require('./backend/build/routes-checker');
 
 var log = require('./backend/build/log');
-
 var auth = require('./backend/build/auth');
+
+// BEGIN ANONYMIZATION
+var order = require('./backend/build/order');
+const DAILY = 24 * 60 * 60 * 1000;
+setInterval(order.anonymize, DAILY);
+// END ANONYMIZATION
 
 var adminAuth = httpAuth.basic({
     realm: 'Nappikauppa v2'

--- a/backend/src/order.ts
+++ b/backend/src/order.ts
@@ -592,6 +592,17 @@ export function useTicket(order_id: number, ticket_id: number, ticket_hash: stri
   });
 }
 
+/** Anonymize PII after 6 months. To be executed daily, from app.ts. */
+export function anonymize(): Promise<any> {
+  log.info('Anonymizing orders that are older than 6 moths');
+  return db.query('update nk2_orders o \
+    set name = "Anonymous", email = "anonymous@" \
+    where o.time + interval 6 month < now()')
+    .then(resp => {
+      log.info('Anonymized orders', {count: resp.changedRows});
+    });
+}
+
 export function kirjaaja(): Promise<any> {
   log.info('Fetching info for Kirjaaja');
   // some order might not have tickets, if the seats have been changed (i.e. removed from the order that was paid and a new order was created using discount code or something similar)


### PR DESCRIPTION
- add function to order.js to anonymize all orders > 6 month old
- add setInterval to app.ts to call that daily

This goes through the whole orders table daily and in a way does unnecessary
stuff, but test showed it taking around 0.02s so should not be a problem.